### PR TITLE
Added support for https

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.1.2
+
+* Added support for self-signed SSL certificates.
+
 ## v0.1.1
 
 * Updated the required parameter to use the proper capitalization of `false` for use in JSON schema

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ clean-pyc:
 	@echo
 	@echo "==================== clean-pyc ===================="
 	@echo
-	find $(ROOT_DIR) -name 'ci' -prune -or -name '.git' -or -type f -name "*.pyc" -print | xargs rm
+	find $(ROOT_DIR) -name 'ci' -prune -or -name '.git' -or -type f -name "*.pyc" -print | xargs -r rm
 
 # list all makefile targets
 .PHONY: list

--- a/actions/lib/run_operation.py
+++ b/actions/lib/run_operation.py
@@ -1,5 +1,6 @@
 from st2common.runners.base_action import Action
 
+from requests import Session
 import zeep
 import zeep.helpers
 
@@ -8,7 +9,7 @@ CONFIG_CONNECTION_KEYS = [('server', True, ""),
                           ('username', True, ""),
                           ('password', True, ""),
                           ('port', False, ""),
-                          ('transport', False, "http"),
+                          ('transport', False, "https"),
                           ('wsdl_endpoint', False, "_mmwebext/mmwebext.dll?wsdl")]
 
 
@@ -190,7 +191,16 @@ class RunOperation(Action):
         session = self.get_del_arg('session', kwargs_dict)
         connection = self.resolve_connection(kwargs_dict)
         wsdl_url = self.build_wsdl_url(connection)
-        client = zeep.Client(wsdl=wsdl_url)
+
+        client = None
+        if connection['transport'] == "https":
+            transport_session = Session()
+            transport_session.verify = False
+            transport = zeep.transports.Transport(session=transport_session)
+            client = zeep.Client(wsdl=wsdl_url, transport=transport)
+        else:
+            client = zeep.Client(wsdl=wsdl_url)
+
         context = {'kwargs_dict': kwargs_dict,
                    'operation': operation,
                    'session': session,

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - mice
     - ipam
     - dns
-version: 0.1.1
+version: 0.1.2
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_run_operation.py
+++ b/tests/test_action_lib_run_operation.py
@@ -78,6 +78,7 @@ class TestActionLibRunOperation(MenAndMiceBaseActionTestCase):
         kwargs_dict = {'connection': connection_name}
         connection_result = action.resolve_connection(kwargs_dict)
         self.assertEqual(connection_result, connection_expected)
+        self.assertEqual(connection_result['transport'], 'https')
 
     def test_resolve_connection_from_kwargs(self):
         action = self.get_action_instance(self.config_blank)
@@ -106,6 +107,7 @@ class TestActionLibRunOperation(MenAndMiceBaseActionTestCase):
 
         connection_result = action.resolve_connection(kwargs_dict)
         self.assertEqual(connection_result, connection_expected)
+        self.assertEqual(connection_result['transport'], 'https')
         self.assertEqual(kwargs_dict, {})
 
     def test_resolve_connection_from_kwargs_extras(self):
@@ -208,7 +210,8 @@ class TestActionLibRunOperation(MenAndMiceBaseActionTestCase):
                        'session': 'abc123',
                        'server': 'menandmice.domain.tld',
                        'username': 'user',
-                       'password': 'pass'}
+                       'password': 'pass',
+                       'transport': 'http'}
         kwargs_dict_extras = {'arg1': 'value1',
                               'arg2': 'value2'}
         kwargs_dict.update(kwargs_dict_extras)
@@ -233,7 +236,8 @@ class TestActionLibRunOperation(MenAndMiceBaseActionTestCase):
         self.assertEquals(result_context, expected_context)
 
     @mock.patch('lib.run_operation.zeep.Client')
-    def test__pre_exec_config(self, mock_client):
+    @mock.patch('lib.run_operation.zeep.transports.Transport')
+    def test__pre_exec_config(self, mock_transport, mock_client):
         action = self.get_action_instance(self.config_good)
         connection_name = 'full'
         kwargs_dict = {'operation': 'GetDNSViews',
@@ -258,7 +262,7 @@ class TestActionLibRunOperation(MenAndMiceBaseActionTestCase):
         kwargs_dict_copy = copy.deepcopy(kwargs_dict)
 
         result_context, result_client = action._pre_exec(**kwargs_dict_copy)
-        mock_client.assert_called_with(wsdl=wsdl_url)
+        mock_client.assert_called_with(transport=mock_transport.return_value, wsdl=wsdl_url)
         self.assertEquals(result_client, mock_client.return_value)
         self.assertEquals(result_context, expected_context)
 


### PR DESCRIPTION
Previously, `https` was throwing cert validation errors when connecting. This adds support for self-signed certs.