### PR TITLE
Feature/utility actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Added action/workflow to get all dns records and related records in a given dns zone.
 * Added action/workflow to claim a dns record.
+* Converted all workflows to orquesta.
   Contributed by Bradley Bishop (Encore Technologies)
 
 ## v0.1.3

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## v0.1.4
+
+* Added action/workflow to get all dns records and related records in a given dns zone.
+* Added action/workflow to claim a dns record.
+  Contributed by Bradley Bishop (Encore Technologies)
+
 ## v0.1.3
 
 * Added action/workflow to delete dns record and all associated related records and PTR records.

--- a/actions/dns_record_claim.yaml
+++ b/actions/dns_record_claim.yaml
@@ -1,0 +1,66 @@
+---
+description: "This is a workflow to claim a dns record in Men and Mice. We will get the next available ip address in the given range if not given."
+enabled: true
+runner_type: orquesta
+entry_point: workflows/dns_record_claim.yaml
+name: dns_record_claim
+pack: menandmice
+parameters:
+  connection:
+    type: string
+    description: "Name of <connection> from this pack's configuration that specifies how to connect to a Men&Mice server."
+    required: false
+  server:
+    type: string
+    description: "Optional override of the Men&Mice server in <connection> (required if <connection> is not specified)."
+    required: false
+  username:
+    type: string
+    description: "Optional override of the Men&Mice username in <connection> (example: username@domain.tld) (required if <connection> is not specified)."
+    required: false
+  password:
+    type: string
+    description: "Optional override of the Men&Mice password in <connection>. (required if <connection> is not specified)"
+    required: false
+    secret: true
+  port:
+    type: integer
+    description: "Optional override of the Men&Mice port in <connection>."
+    required: false
+  transport:
+    type: string
+    description: "Optional override of the Men&Mice transport in <connection>."
+    required: false
+  session:
+    type: string
+    required: false
+    description: "Login session cookie. If empty then username/password will be used to login prior to running this operation"
+    default: ''
+  dns_domain:
+    type: string
+    description: "DNS name of the record eg. 'domain.tld'"
+    required: true
+  hostname:
+    type: string
+    description: "Name of the DNS record"
+    required: true
+  ip_address:
+    type: string
+    description: "IP address of the DNS Record"
+    default: ''
+  range_name:
+    type: string
+    description: "Name of the range to get the next available ip address from."
+    required: false
+  record_enabled:
+    type: boolean
+    description: "If the record should be enabled."
+    default: true
+  record_type:
+    type: string
+    description: "The type of record that is being created. eg. A, CNAME"
+    default: A
+  related_record_name:
+    type: string
+    description: "Name of the record that is being referenced. eg for CNAMEs. ex. test.domain.tld"
+    required: false

--- a/actions/dns_record_claim.yaml
+++ b/actions/dns_record_claim.yaml
@@ -33,7 +33,6 @@ parameters:
     required: false
   session:
     type: string
-    required: false
     description: "Login session cookie. If empty then username/password will be used to login prior to running this operation"
     default: ''
   dns_domain:

--- a/actions/get_zone_dns_records.py
+++ b/actions/get_zone_dns_records.py
@@ -1,0 +1,125 @@
+from st2common.runners.base_action import Action
+
+
+class GetZoneDNSRecords(Action):
+
+    def __init__(self, config):
+        super(GetZoneDNSRecords, self).__init__(config)
+
+    def get_dns_zone(self, url, client, dns_domain):
+        """Query the Men and Mice API for the DNS Name to get the
+        DNS zone that the DNS record will live in. Need to return just the
+        record reference object so it can used later. Verify that the call
+        was successful by checking the response code (Expecting: 200)
+        Returns: string containing zone referenct ex: dnszone/44
+        """
+        dns_zone_filter = "type:^Master$ name:^{0}$".format(self.check_dns_name(dns_domain))
+        dns_response = client.get("{0}/DNSZones?filter={1}".format(url, dns_zone_filter))
+        dns_response.raise_for_status()
+        dns_json = dns_response.json()
+        dns_zones = dns_json["result"]["dnsZones"]
+
+        return dns_zones[0]["ref"]
+
+    def get_dns_records(self, url, client, dns_zone_ref):
+        """Get all the DNS A records for the dns zone that was
+        found before. We only care about A records. (Expecting: 200)
+        Returns: Array of dictionaries containin all records withing
+        zone
+        """
+        dns_record_filter = "?filter=type:^A$"
+        dns_record_response = client.get("{0}/{1}/DNSRecords{2}".format(url,
+                                                                        dns_zone_ref,
+                                                                        dns_record_filter))
+        dns_record_response.raise_for_status()
+        dns_records = dns_record_response.json()
+
+        return dns_records["result"]["dnsRecords"]
+
+    def resolve_fqdn(self, url, client, dns_record):
+        """Takes a DNS record weather that is a related
+        record or a normal DNS record and finds the Zone name from
+        the Zone Ref that is given with the record then combines it
+        with the name of the dns record to make sure that the fqdn
+        is correct.
+        Returns: String
+        """
+        dns_zone_response = client.get("{0}/{1}".format(url, dns_record['dnsZoneRef']))
+        dns_zone_response.raise_for_status()
+        dns_zone = dns_zone_response.json()
+
+        dns_zone_name = dns_zone['result']['dnsZone']['name']
+        if dns_zone_name.endswith('.'):
+            dns_zone_name = dns_zone_name[:-1]
+
+        fqdn = "{0}.{1}".format(dns_record['name'], dns_zone_name)
+
+        return fqdn
+
+    def get_dns_related_records(self, url, client, dns_record_ref):
+        """Gets all the related records from the DNS A record that was
+        found above. If related records exist we need to generate the
+        FQDN for the record before we continue
+        Returns: Array of Dictionairies containing all related records
+        """
+        dns_related_record_response = client.get(("{0}/{1}/RelatedDNSRecords"
+                                                  "".format(url, dns_record_ref)))
+        dns_related_record_response.raise_for_status()
+        dns_related_records_json = dns_related_record_response.json()
+
+        # Always returned as an array maybe empty but will always be array.
+        dns_related_records = []
+        for related_record in dns_related_records_json["result"]["dnsRecords"]:
+            related_record_fqdn = self.resolve_fqdn(url, client, related_record)
+            related_record['name_fqdn'] = related_record_fqdn
+            dns_related_records.append(related_record)
+
+        return dns_related_records
+
+    def build_dns_information(self, url, client, dns_records, dns_domain):
+        """Takes all dns_records and looks for any related records and compiles
+        that into 1 list to be returned.
+        Returns: Dictionairies containing all dns records
+        """
+        dns_dict = {}
+        for record in dns_records:
+            record_fqdn = "{0}.{1}".format(record['name'], dns_domain)
+            related_records = self.get_dns_related_records(url, client, record['ref'])
+            dns_dict[record_fqdn] = record
+            dns_dict[record_fqdn]['related_records'] = related_records
+
+        return dns_dict
+
+    def mm_build_client(self, kwargs_dict):
+        """Build the rest client that will be used in all of our calls.
+        Do auth here and pass that along with the client. Also we build
+        the base url that can just be appended as needed in later calls
+        """
+        server = self.get_arg("server", kwargs_dict)
+        username = self.get_arg("username", kwargs_dict)
+        password = self.get_arg("password", kwargs_dict)
+        transport = self.get_arg("transport", kwargs_dict)
+        url = "{0}://{1}/mmws/api".format(transport, server)
+
+        client = requests.Session()
+        client.auth = (username, password)
+
+        if transport == "https":
+            client.verify = False
+
+        return (url, client)
+
+    def run(self, **kwargs):
+        """Main entry point for the StackStorm actions to get all the information
+        needed to build the dns entry from scratch.
+        """
+        kwargs_dict = dict(kwargs)
+
+        dns_domain = kwargs['dns_domain']
+        url, client = self.mm_build_client(kwargs_dict)
+
+        dns_zone_ref = self.get_dns_zone(url, client, dns_domain)
+        dns_records = self.get_dns_records(url, client, dns_zone_ref)
+        dns_dict = self.build_dns_information(url, client, dns_records, dns_domain)
+
+        return dns_dict

--- a/actions/get_zone_dns_records.py
+++ b/actions/get_zone_dns_records.py
@@ -1,10 +1,21 @@
 from st2common.runners.base_action import Action
+import requests
 
 
 class GetZoneDNSRecords(Action):
 
     def __init__(self, config):
         super(GetZoneDNSRecords, self).__init__(config)
+
+    def check_dns_name(self, name):
+        """DNS names have to have a . at the end of the name for
+        Men and Mice to see it properly and not append additional
+        Information.
+        """
+        if not name.endswith('.'):
+            name += '.'
+
+        return name
 
     def get_dns_zone(self, url, client, dns_domain):
         """Query the Men and Mice API for the DNS Name to get the
@@ -95,10 +106,10 @@ class GetZoneDNSRecords(Action):
         Do auth here and pass that along with the client. Also we build
         the base url that can just be appended as needed in later calls
         """
-        server = self.get_arg("server", kwargs_dict)
-        username = self.get_arg("username", kwargs_dict)
-        password = self.get_arg("password", kwargs_dict)
-        transport = self.get_arg("transport", kwargs_dict)
+        server = kwargs_dict['server']
+        username = kwargs_dict['username']
+        password = kwargs_dict['password']
+        transport = kwargs_dict['transport']
         url = "{0}://{1}/mmws/api".format(transport, server)
 
         client = requests.Session()
@@ -113,10 +124,8 @@ class GetZoneDNSRecords(Action):
         """Main entry point for the StackStorm actions to get all the information
         needed to build the dns entry from scratch.
         """
-        kwargs_dict = dict(kwargs)
-
         dns_domain = kwargs['dns_domain']
-        url, client = self.mm_build_client(kwargs_dict)
+        url, client = self.mm_build_client(kwargs)
 
         dns_zone_ref = self.get_dns_zone(url, client, dns_domain)
         dns_records = self.get_dns_records(url, client, dns_zone_ref)

--- a/actions/get_zone_dns_records.yaml
+++ b/actions/get_zone_dns_records.yaml
@@ -1,0 +1,33 @@
+---
+description: "This is a workflow to get DNS records out of Men&Mice zone"
+enabled: true
+runner_type: "python-script"
+entry_point: get_zone_dns_records.py
+name: get_zone_dns_records
+pack: encore
+parameters:
+  server:
+    type: string
+    description: "The FQDN of the Men and Mice server"
+    required: true
+    default: "{{ st2kv.system.menandmice.server }}"
+  username:
+    type: string
+    description: "Username to log into the Men and Mice server"
+    required: true
+    default: "{{ st2kv.system.menandmice.username }}"
+  password:
+    type: string
+    description: "Password to log into the Men and Mice server"
+    required: true
+    default: "{{ st2kv.system.menandmice.password | decrypt_kv }}"
+    secret: true
+  transport:
+    type: string
+    description: "transport needed to log into the Men and Mice server ex. http, https"
+    required: true
+    default: "{{ st2kv.system.menandmice.transport }}"
+  dns_domain:
+    type: string
+    description: "DNS name of the record eg. 'domain.tld'"
+    required: true

--- a/actions/get_zone_dns_records.yaml
+++ b/actions/get_zone_dns_records.yaml
@@ -4,7 +4,7 @@ enabled: true
 runner_type: "python-script"
 entry_point: get_zone_dns_records.py
 name: get_zone_dns_records
-pack: encore
+pack: menandmice
 parameters:
   server:
     type: string

--- a/actions/lib/run_operation.py
+++ b/actions/lib/run_operation.py
@@ -12,6 +12,8 @@ CONFIG_CONNECTION_KEYS = [('server', True, ""),
                           ('transport', False, "https"),
                           ('wsdl_endpoint', False, "_mmwebext/mmwebext.dll?wsdl")]
 
+PARAM_OVERIRDES = {'exclude_dhcp': 'excludeDHCP'}
+
 
 class RunOperation(Action):
 
@@ -27,7 +29,13 @@ class RunOperation(Action):
         :param snake_cased_str: snake cased string
         :returns: string converted into camel case
         """
-        return self._convert_to_camel(snake_cased_str, "_")
+        camel_cased_return = ""
+        if snake_cased_str in PARAM_OVERIRDES.keys():
+            camel_cased_return = PARAM_OVERIRDES[snake_cased_str]
+        else:
+            camel_cased_return = self._convert_to_camel(snake_cased_str, "_")
+
+        return camel_cased_return
 
     def _convert_to_camel(self, snake_cased_str, separator):
         components = snake_cased_str.split(separator)

--- a/actions/remove_dns_record.yaml
+++ b/actions/remove_dns_record.yaml
@@ -1,7 +1,7 @@
 ---
 description: "This is a workflow to delete DNS records out of Men&Mice"
 enabled: true
-runner_type: "mistral-v2"
+runner_type: orquesta
 entry_point: workflows/remove_dns_record.yaml
 name: remove_dns_record
 pack: menandmice

--- a/actions/resolve_fqdn.yaml
+++ b/actions/resolve_fqdn.yaml
@@ -1,10 +1,10 @@
 ---
 description: "Create an fqdn from the Men&Mice name and Zone info"
 enabled: true
+runner_type: orquesta
 entry_point: workflows/resolve_fqdn.yaml
 name: resolve_fqdn
 pack: menandmice
-runner_type: "mistral-v2"
 parameters:
   connection:
     type: string

--- a/actions/test_credentials.yaml
+++ b/actions/test_credentials.yaml
@@ -1,7 +1,7 @@
 ---
 description: "Test the credentials to login to Men&Mice"
 enabled: true
-runner_type: "mistral-v2"
+runner_type: orquesta
 entry_point: workflows/test_credentials.yaml
 name: test_credentials
 pack: menandmice

--- a/actions/test_hostname.yaml
+++ b/actions/test_hostname.yaml
@@ -1,7 +1,7 @@
 ---
 description: "Test hostname to see if it is already in use in Men&Mice"
 enabled: true
-runner_type: "mistral-v2"
+runner_type: orquesta
 entry_point: workflows/test_hostname.yaml
 name: test_hostname
 pack: menandmice

--- a/actions/wf_add_dns_zone.yaml
+++ b/actions/wf_add_dns_zone.yaml
@@ -1,6 +1,7 @@
 ---
-description: Create master DNS zone
+description: "Create master DNS zone"
 enabled: true
+runner_type: orquesta
 entry_point: workflows/wf_add_dns_zone.yaml
 name: wf_add_dns_zone
 pack: menandmice
@@ -42,4 +43,3 @@ parameters:
     type: string
     description: "Hostname of the master DNS server for this new zone."
     required: true
-runner_type: mistral-v2

--- a/actions/workflows/dns_record_claim.yaml
+++ b/actions/workflows/dns_record_claim.yaml
@@ -19,6 +19,9 @@ input:
   - record_type
   - related_record_name
 
+vars:
+  - dns_record: null
+
 output:
   - ip_address: "{{ ctx().ip_address }}"
   - dns_record: "{{ ctx().dns_record }}"
@@ -27,10 +30,12 @@ tasks:
   main:
     action: core.noop
     next:
-      - when: "{{ succeeded() }}"
+      - when: "{{ succeeded() and (ctx().session == '') }}"
         do:
-        - login: "{{ ctx().session == '' }}"
-        - dispatch: "{{ ctx().session != '' }}"
+          - login
+      - when: "{{ succeeded() and (ctx().session != '') }}"
+        do:
+          - dispatch
 
   login:
     action: menandmice.login
@@ -51,12 +56,16 @@ tasks:
   dispatch:
     action: core.noop
     next:
-      - when: "{{ succeeded() }}"
+          # We only need an IP address for record if its an A record
+      - when: "{{ succeeded() and (ctx().record_type == 'A' and not ctx().ip_address) }}"
         do:
-        # We only need an IP address for record if its an A record
-        - get_range: "{{ ctx().record_type == A and not ctx().ip_address }}"
-        - get_dns_zone: "{{ ctx().record_type == A and ctx().ip_address }}"
-        - get_dns_zone: "{{ ctx().record_type != A }}"
+          - get_range
+      - when: "{{ succeeded() and (ctx().record_type == 'A' and ctx().ip_address) }}"
+        do:
+          - get_dns_zone
+      - when: "{{ succeeded() and (ctx().record_type != 'A') }}"
+        do:
+          - get_dns_zone
 
   get_range:
     action: menandmice.get_ranges
@@ -68,7 +77,7 @@ tasks:
     next:
       - when: "{{ succeeded() }}"
         publish:
-          - range_ref: "{{ result().result.ranges[0].ref }}"
+          - range_ref: "{{ result().result.ranges.range[0].ref }}"
         do:
           - get_next_ip_address
 
@@ -84,7 +93,7 @@ tasks:
     next:
       - when: "{{ succeeded() }}"
         publish:
-          - ip_address: "{{ result().result.address }}"
+          - ip_address: "{{ result().result }}"
         do:
           - get_dns_zone
 
@@ -110,7 +119,7 @@ tasks:
           - dns_record:
               name: "{{ ctx().hostname }}"
               type: "{{ ctx().record_type }}"
-              data: "{{ ctx().ip_address if ctx().record_type == A else ctx().related_record_name }}"
+              data: "{{ ctx().ip_address if ctx().record_type == 'A' else ctx().related_record_name }}"
               enabled: "{{ ctx().record_enabled }}"
               dnsZoneRef: "{{ ctx().dns_zone_ref }}"
         do:

--- a/actions/workflows/dns_record_claim.yaml
+++ b/actions/workflows/dns_record_claim.yaml
@@ -1,0 +1,125 @@
+---
+version: 1.0
+
+description: This is a workflow to claim a dns record in Men and Mice. We will get the next available ip address in the given range if not given.
+
+input:
+  - connection
+  - server
+  - username
+  - password
+  - port
+  - transport
+  - session
+  - dns_domain
+  - hostname
+  - ip_address
+  - range_name
+  - record_enabled
+  - record_type
+  - related_record_name
+
+output:
+  - ip_address: "{{ ctx().ip_address }}"
+  - dns_record: "{{ ctx().dns_record }}"
+
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+        - login: "{{ ctx().session == '' }}"
+        - dispatch: "{{ ctx().session != '' }}"
+
+  login:
+    action: menandmice.login
+    input:
+      connection: "{{ ctx().connection }}"
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"
+      password: "{{ ctx().password }}"
+      port: "{{ ctx().port }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - session: "{{ result().result.session }}"
+        do:
+          - dispatch
+
+  dispatch:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+        # We only need an IP address for record if its an A record
+        - get_range: "{{ ctx().record_type == A and not ctx().ip_address }}"
+        - get_dns_zone: "{{ ctx().record_type == A and ctx().ip_address }}"
+        - get_dns_zone: "{{ ctx().record_type != A }}"
+
+  get_range:
+    action: menandmice.get_ranges
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      filter: "^{{ ctx().range_name }}$"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - range_ref: "{{ result().result.ranges[0].ref }}"
+        do:
+          - get_next_ip_address
+
+  # Get the next available ip address
+  get_next_ip_address:
+    action: menandmice.get_next_free_address
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      range_ref: "{{ ctx().range_ref }}"
+      temporary_claim_time: 1
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - ip_address: "{{ result().result.address }}"
+        do:
+          - get_dns_zone
+
+  get_dns_zone:
+    action: menandmice.get_dns_zones
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      filter: "type:^Master$ name:^{{ ctx().dns_domain }}.$"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_zone_ref: "{{ result().result.dnsZones.dnsZone[0].ref }}"
+        do:
+          - build_dns_record
+
+  build_dns_record:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_record:
+              name: "{{ ctx().hostname }}"
+              type: "{{ ctx().record_type }}"
+              data: "{{ ctx().ip_address if ctx().record_type == A else ctx().related_record_name }}"
+              enabled: "{{ ctx().record_enabled }}"
+              dnsZoneRef: "{{ ctx().dns_zone_ref }}"
+        do:
+          - add_dns_record
+
+  add_dns_record:
+    action: menandmice.add_dns_record
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      dns_record: "{{ ctx().dns_record }}"

--- a/actions/workflows/remove_dns_record.yaml
+++ b/actions/workflows/remove_dns_record.yaml
@@ -1,153 +1,167 @@
-version: '2.0'
+---
+version: 1.0
 
-menandmice.remove_dns_record:
-  description: >
-    This is a workflow to delete DNS records out of Men&Mice
-  type: direct
-  input:
-    - connection
-    - server
-    - username
-    - password
-    - port
-    - transport
-    - session
-    - dns_domain
-    - ip_address
-    - name
+description: This is a workflow to delete DNS records out of Men&Mice
 
-  tasks:
-    main:
-      action: std.noop
-      on-success:
-        - login: "{{ _.session == '' }}"
-        - get_dns_servers: "{{ _.session != '' }}"
+input:
+  - connection
+  - server
+  - username
+  - password
+  - port
+  - transport
+  - session
+  - dns_domain
+  - ip_address
+  - name
 
-    login:
-      action: menandmice.login
-      input:
-        connection: "{{ _.connection }}"
-        server: "{{ _.server }}"
-        username: "{{ _.username }}"
-        password: "{{ _.password }}"
-        port: "{{ _.port }}"
-        transport: "{{ _.transport }}"
-      publish:
-        session: "{{ task('login').result.result.session }}"
-      on-success:
-        - get_dns_servers
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() and (ctx().session == '') }}"
+        do:
+          - login
+      - when: "{{ succeeded() and (ctx().session != '') }}"
+        do:
+          - get_dns_servers
 
-    # Gets all DNS servers
-    get_dns_servers:
-      action: menandmice.get_dns_servers
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-      publish:
-        # note: flatten() is needed because otherwise it's an array of arrays
-        dns_server_refs: <% task(get_dns_servers).result.result.dnsServers.dnsServer.ref.flatten() %>
-      on-success:
-        - get_dns_zone
+  login:
+    action: menandmice.login
+    input:
+      connection: "{{ ctx().connection }}"
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"
+      password: "{{ ctx().password }}"
+      port: "{{ ctx().port }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - session: "{{ result().result.session }}"
+        do:
+          - get_dns_servers
 
-    get_dns_zone:
-      action: menandmice.get_dns_zones
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        filter: "type:^Master$ name:^{{ _.dns_domain }}.$"
-      publish:
-        dns_zone_ref: "{{ task('get_dns_zone').result.result.dnsZones.dnsZone[0].ref }}"
-      on-success:
-        - get_dns_record
+  get_dns_servers:
+    action: menandmice.get_dns_servers
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_server_refs: <% result().result.dnsServers.dnsServer.ref.flatten() %>
+        do:
+          - get_dns_zone
 
-    # Does not allow duplicates to be added
-    get_dns_record:
-      action: menandmice.get_dns_records
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        dns_zone_ref: "{{ _.dns_zone_ref }}"
-        filter: "name:{{ _.name }} AND type:A"
-      publish:
-        dns_record_ref: "{{ task('get_dns_record').result.result.dnsRecords.dnsRecord[0].ref }}"
-        dns_record: "{{ task('get_dns_record').result.result.dnsRecords.dnsRecord[0] }}"
-      on-success:
-        - get_related_records
+  get_dns_zone:
+    action: menandmice.get_dns_zones
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      filter: type:^Master$ name:^{{ ctx().dns_domain }}.$
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_zone_ref: "{{ result().result.dnsZones.dnsZone[0].ref }}"
+        do:
+          - get_dns_record
 
-    # Can potentially have many records or None
-    get_related_records:
-      action: menandmice.get_related_dns_records
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        dns_record_ref: "{{ _.dns_record_ref }}"
-      publish:
-        dns_releated_records_refs: "{{ task('get_related_records').result.result | map(attribute='ref') | list if task('get_related_records').result.result != None else [] }}"
-        dns_releated_records: "{{ task('get_related_records').result.result if task('get_related_records').result.result != None else [] }}"
-      on-success:
-        - merge_records
+  get_dns_record:
+    action: menandmice.get_dns_records
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      dns_zone_ref: "{{ ctx().dns_zone_ref }}"
+      filter: name:{{ ctx().name }} AND type:A
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_record_ref: "{{ result().result.dnsRecords.dnsRecord[0].ref }}"
+          - dns_record: "{{ result().result.dnsRecords.dnsRecord[0] }}"
+        do:
+          - get_related_records
 
-    merge_records:
-      action: std.noop
-      publish:
-        records_to_remove: "{{ [ _.dns_record_ref ] + _.dns_releated_records_refs }}"
-        dns_records_to_flush: "{{ [ _.dns_record ] + _.dns_releated_records }}"
-      on-success:
-        - get_dns_ptr_record
+  get_related_records:
+    action: menandmice.get_related_dns_records
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      dns_record_ref: "{{ ctx().dns_record_ref }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_releated_records_refs: "{{ result().result | map(attribute='ref') | list if result().result != None else [] }}"
+          - dns_releated_records: "{{ result().result if result().result != None else [] }}"
+        do:
+          - merge_records
 
-    # Does not allow duplicates to be added
-    get_dns_ptr_record:
-      action: menandmice.get_dnsptr_records
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        address: "{{ _.ip_address }}"
-        dns_zone_ref: "{{ _.dns_zone_ref }}"
-      publish:
-        records_to_remove: "{{ _.records_to_remove + [ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0].ref ] if task('get_dns_ptr_record').result.result.totalResults != 0 else _.records_to_remove }}"
-        dns_records_to_flush: "{{ _.dns_records_to_flush + [ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0] ] if task('get_dns_ptr_record').result.result.totalResults != 0 else _.dns_records_to_flush }}"
-      on-success:
-        - resolve_fqdn
+  merge_records:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - records_to_remove: "{{ [ ctx().dns_record_ref ] + ctx().dns_releated_records_refs }}"
+          - dns_records_to_flush: "{{ [ ctx().dns_record ] + ctx().dns_releated_records }}"
+        do:
+          - get_dns_ptr_record
 
-    # DNS records only come in with the hostname. We need to convert to FQDNs
-    resolve_fqdn:
-      with-items: "record in {{ _.dns_records_to_flush }}"
-      action: menandmice.resolve_fqdn
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        dns_zone_ref: "{{ _.record.dnsZoneRef }}"
-        name: "{{ _.record.name }}"
-      publish:
-        # This is done in YAQL because it automatically returns as an array
-        entries_to_flush: <% task('resolve_fqdn').result.fqdn %>
-      on-success:
-        - remove_dns_records
+  get_dns_ptr_record:
+    action: menandmice.get_dnsptr_records
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      address: "{{ ctx().ip_address }}"
+      dns_zone_ref: "{{ ctx().dns_zone_ref }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - records_to_remove: "{{ ctx().records_to_remove + [ result().result.reverseRecords.dnsRecord[0].ref ] if result().result.totalResults != 0 else ctx().records_to_remove }}"
+          - dns_records_to_flush: "{{ ctx().dns_records_to_flush + [ result().result.reverseRecords.dnsRecord[0] ] if result().result.totalResults != 0 else ctx().dns_records_to_flush }}"
+        do:
+          - resolve_fqdn
 
-    remove_dns_records:
-      action: menandmice.remove_objects
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        obj_refs:
-          ref: "{{ _.records_to_remove }}"
-      on-success:
-        - flush_dns_cache
+  resolve_fqdn:
+    with: "{{ ctx().dns_records_to_flush }}"
+    action: menandmice.resolve_fqdn
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      dns_zone_ref: "{{ item().dnsZoneRef }}"
+      name: "{{ item().name }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - entries_to_flush: <% result().output.fqdn %>
+        do:
+          - remove_dns_records
 
-    flush_dns_cache:
-      with-items: "entry in {{ _.entries_to_flush }}"
-      action: menandmice.flush_from_cache_on_dns_servers
-      input:
-        session: "{{ _.session }}"
-        server: "{{ _.server }}"
-        transport: "{{ _.transport }}"
-        dns_server_refs:
-          ref: "{{ _.dns_server_refs }}"
-        entry: "{{ _.entry }}"
+  remove_dns_records:
+    action: menandmice.remove_objects
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      obj_refs:
+        ref: "{{ ctx().records_to_remove }}"
+    next:
+      - when: "{{ succeeded() }}"
+        do:
+          - flush_dns_cache
+
+  flush_dns_cache:
+    with: "{{ ctx().entries_to_flush }}"
+    action: menandmice.flush_from_cache_on_dns_servers
+    input:
+      session: "{{ ctx().session }}"
+      server: "{{ ctx().server }}"
+      transport: "{{ ctx().transport }}"
+      dns_server_refs:
+        ref: "{{ ctx().dns_server_refs }}"
+      entry: "{{ item() }}"

--- a/actions/workflows/remove_dns_record.yaml
+++ b/actions/workflows/remove_dns_record.yaml
@@ -89,6 +89,14 @@ menandmice.remove_dns_record:
         dns_releated_records_refs: "{{ task('get_related_records').result.result | map(attribute='ref') | list if task('get_related_records').result.result != None else [] }}"
         dns_releated_records: "{{ task('get_related_records').result.result if task('get_related_records').result.result != None else [] }}"
       on-success:
+        - merge_records
+
+    merge_records:
+      action: std.noop
+      publish:
+        records_to_remove: "{{ [ _.dns_record_ref ] + _.dns_releated_records_refs }}"
+        dns_records_to_flush: "{{ [ _.dns_record ] + _.dns_releated_records }}"
+      on-success:
         - get_dns_ptr_record
 
     # Does not allow duplicates to be added
@@ -101,16 +109,8 @@ menandmice.remove_dns_record:
         address: "{{ _.ip_address }}"
         dns_zone_ref: "{{ _.dns_zone_ref }}"
       publish:
-        dns_ptr_ref: "{{ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0].ref }}"
-        ptr_record: "{{ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0] }}"
-      on-success:
-        - merge_records
-
-    merge_records:
-      action: std.noop
-      publish:
-        records_to_remove: "{{ [ _.dns_record_ref, _.dns_ptr_ref ] + _.dns_releated_records_refs }}"
-        dns_records_to_flush: "{{ [ _.dns_record, _.ptr_record ] + _.dns_releated_records }}"
+        records_to_remove: "{{ _.records_to_remove + [ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0].ref ] if task('get_dns_ptr_record').result.result.totalResults != 0 else _.records_to_remove }}"
+        dns_records_to_flush: "{{ _.dns_records_to_flush + [ task('get_dns_ptr_record').result.result.reverseRecords.dnsRecord[0] ] if task('get_dns_ptr_record').result.result.totalResults != 0 else _.dns_records_to_flush }}"
       on-success:
         - resolve_fqdn
 

--- a/actions/workflows/resolve_fqdn.yaml
+++ b/actions/workflows/resolve_fqdn.yaml
@@ -1,50 +1,57 @@
-version: '2.0'
+---
+version: 1.0
 
-menandmice.resolve_fqdn:
-  description: >
-    Create an fqdn from the M&M name and Zone info
-  type: direct
-  input:
-    - connection
-    - server
-    - username
-    - password
-    - port
-    - transport
-    - session
-    - dns_zone_ref
-    - name
+description: Create an fqdn from the M&M name and Zone info
 
-  output:
-    fqdn: "{{ _.fqdn }}"
+input:
+  - connection
+  - server
+  - username
+  - password
+  - port
+  - transport
+  - session
+  - dns_zone_ref
+  - name
 
-  tasks:
-    main:
-      action: std.noop
-      on-success:
-        - login: "{{ _.session == '' }}"
-        - get_dns_zone: "{{ _.session != '' }}"
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() and (ctx().session == '') }}"
+        do:
+          - login
+      - when: "{{ succeeded() and (ctx().session != '') }}"
+        do:
+          - get_dns_zone
 
-    login:
-      action: menandmice.login
-      input:
-        connection: "{{ _.connection }}"
-        server: "{{ _.server }}"
-        username: "{{ _.username }}"
-        password: "{{ _.password }}"
-        port: "{{ _.port }}"
-        transport: "{{ _.transport }}"
-      publish:
-        session: "{{ task('login').result.result.session }}"
-      on-success:
-        - get_dns_zone
+  login:
+    action: menandmice.login
+    input:
+      connection: "{{ ctx().connection }}"
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"
+      password: "{{ ctx().password }}"
+      port: "{{ ctx().port }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - session: "{{ result().result.session }}"
+        do:
+          - get_dns_zone
 
-    get_dns_zone:
-      action: menandmice.get_dns_zone
-      input:
-        server: "{{ _.server }}"
-        session: "{{ _.session }}"
-        transport: "{{ _.transport }}"
-        dns_zone_ref: "{{ _.dns_zone_ref }}"
-      publish:
-        fqdn: "{{ _.name + '.' + task('get_dns_zone').result.result.name }}"
+  get_dns_zone:
+    action: menandmice.get_dns_zone
+    input:
+      server: "{{ ctx().server }}"
+      session: "{{ ctx().session }}"
+      transport: "{{ ctx().transport }}"
+      dns_zone_ref: "{{ ctx().dns_zone_ref }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - fqdn: "{{ ctx().name + '.' + result().result.name }}"
+
+output:
+  - fqdn: "{{ ctx().fqdn }}"

--- a/actions/workflows/test_credentials.yaml
+++ b/actions/workflows/test_credentials.yaml
@@ -1,39 +1,36 @@
-version: '2.0'
+---
+version: 1.0
 
-menandmice.test_credentials:
-  description: >
-    Test the credentials to login to Men&Mice
-  type: direct
-  input:
-    - connection
-    - server
-    - username
-    - password
-    - port
-    - transport
+description: Test the credentials to login to Men&Mice
 
-  output:
-    result: "{{ _.result }}"
-    data:
-      server: "{{ _.server }}"
-      username: "{{ _.username }}"
-  output-on-error:
-    result: "{{ _.result }}"
-    data:
-      server: "{{ _.server }}"
-      username: "{{ _.username }}"
+input:
+  - connection
+  - server
+  - username
+  - password
+  - port
+  - transport
 
-  tasks:
-    main:
-      action: menandmice.login
-      input:
-        connection: "{{ _.connection }}"
-        server: "{{ _.server }}"
-        username: "{{ _.username }}"
-        password: "{{ _.password }}"
-        port: "{{ _.port }}"
-        transport: "{{ _.transport }}"
-      publish:
-        result: "{{ task('main').result }}"
-      publish-on-error:
-        result: "{{ task('main').result }}"
+tasks:
+  main:
+    action: menandmice.login
+    input:
+      connection: "{{ ctx().connection }}"
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"
+      password: "{{ ctx().password }}"
+      port: "{{ ctx().port }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - result: "{{ result() }}"
+      - when: "{{ failed() }}"
+        publish:
+          - result: "{{ result() }}"
+
+output:
+  - result: "{{ ctx().result }}"
+  - data:
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"

--- a/actions/workflows/test_hostname.yaml
+++ b/actions/workflows/test_hostname.yaml
@@ -1,61 +1,72 @@
-version: '2.0'
+---
+version: 1.0
 
-menandmice.test_hostname:
-  description: >
-    Test hostname to see if it is already in use in Men&Mice
-  type: direct
-  input:
-    - connection
-    - server
-    - username
-    - password
-    - port
-    - transport
-    - session
-    - dns_domain
-    - hostname
+description: Test hostname to see if it is already in use in Men&Mice
 
-  tasks:
-    main:
-      action: std.noop
-      on-success:
-        - login: "{{ _.session == '' }}"
-        - get_dns_zone: "{{ _.session != '' }}"
+input:
+  - connection
+  - server
+  - username
+  - password
+  - port
+  - transport
+  - session
+  - dns_domain
+  - hostname
 
-    login:
-      action: menandmice.login
-      input:
-        connection: "{{ _.connection }}"
-        server: "{{ _.server }}"
-        username: "{{ _.username }}"
-        password: "{{ _.password }}"
-        port: "{{ _.port }}"
-        transport: "{{ _.transport }}"
-      publish:
-        session: "{{ task('login').result.result.session }}"
-      on-success:
-        - get_dns_zone
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() and (ctx().session == '') }}"
+        do:
+          - login
+      - when: "{{ succeeded() and (ctx().session != '') }}"
+        do:
+          - get_dns_zone
 
-    get_dns_zone:
-      action: menandmice.get_dns_zones
-      input:
-        session: "{{ _.session }}"
-        server: "{{ _.server }}"
-        transport: "{{ _.transport }}"
-        filter: "type:master name:^{{ _.dns_domain }}.$"
-      publish:
-        dns_zone_ref: "{{ task('get_dns_zone').result.result.dnsZones.dnsZone[0].ref }}"
-      on-success:
-        - check_dns_name
+  login:
+    action: menandmice.login
+    input:
+      connection: "{{ ctx().connection }}"
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"
+      password: "{{ ctx().password }}"
+      port: "{{ ctx().port }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - session: "{{ result().result.session }}"
+        do:
+          - get_dns_zone
 
-    check_dns_name:
-      action: menandmice.get_dns_records
-      input:
-        session: "{{ _.session }}"
-        server: "{{ _.server }}"
-        transport: "{{ _.transport }}"
-        dns_zone_ref: "{{ _.dns_zone_ref }}"
-        filter: "name:{{ _.hostname }}"
-      on-complete:
-        - fail: "{{ task('check_dns_name').result.result.totalResults > 0 }}"
-        - succeed: "{{ task('check_dns_name').result.result.totalResults == 0 }}"
+  get_dns_zone:
+    action: menandmice.get_dns_zones
+    input:
+      session: "{{ ctx().session }}"
+      server: "{{ ctx().server }}"
+      transport: "{{ ctx().transport }}"
+      filter: type:master name:^{{ ctx().dns_domain }}.$
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - dns_zone_ref: "{{ result().result.dnsZones.dnsZone[0].ref }}"
+        do:
+          - check_dns_name
+
+  check_dns_name:
+    action: menandmice.get_dns_records
+    input:
+      session: "{{ ctx().session }}"
+      server: "{{ ctx().server }}"
+      transport: "{{ ctx().transport }}"
+      dns_zone_ref: "{{ ctx().dns_zone_ref }}"
+      filter: name:{{ ctx().hostname }}
+    next:
+      - when: "{{ result().result.totalResults > 0 }}"
+        do:
+          - fail
+      - when: "{{ result().result.totalResults == 0 }}"
+        do:
+          - noop

--- a/actions/workflows/wf_add_dns_zone.yaml
+++ b/actions/workflows/wf_add_dns_zone.yaml
@@ -1,89 +1,108 @@
-version: '2.0'
+---
+version: 1.0
 
-menandmice.wf_add_dns_zone:
-  description: >
-    A sample workflow that demonstrates how to create a master DNS zone.
-    type: direct
-  input:
-    - session
-    - connection
-    - server
-    - username
-    - password
-    - port
-    - transport
-    - zone_name
-    - master_server
-  output:
-    master_server_ref: "{{ _.master_server_ref }}"
-    master_server_ip: "{{ _.master_server_ip }}"
-    master_view_ref: "{{ _.master_view_ref }}"
-    master_zone_ref: "{{ _.master_zone_ref }}"
-  tasks:
-    main:
-      action: std.noop
-      on-success:
-        - login: "{{ not _.session }}"
-        - get_master_server
+description: A sample workflow that demonstrates how to create a master DNS zone.
 
-    login:
-      action: menandmice.login
-      input:
-        connection: "{{ _.connection }}"
-        server: "{{ _.server }}"
-        username: "{{ _.username }}"
-        password: "{{ _.password }}"
-        port: "{{ _.port }}"
-        transport: "{{ _.transport }}"
-      publish:
-        session: "{{ task('login').result.result.session }}"
-    
-    get_master_server:
-      action: menandmice.get_dns_servers
-      input:
-        session: "{{ _.session }}"
-        server: "{{ _.server }}"
-        filter: "name: {{ _.master_server }}"
-      publish:
-        master_server_obj: "{{ task('get_master_server').result.result.dnsServers.dnsServer[0] }}"
-      on-success:
-        - parse_master_server
+input:
+  - session
+  - connection
+  - server
+  - username
+  - password
+  - port
+  - transport
+  - zone_name
+  - master_server
 
-    parse_master_server:
-      action: std.noop
-      publish:
-        master_server_ref: "{{ _.master_server_obj.ref }}"
-        master_server_ip: "{{ _.master_server_obj.address }}"
-      on-success:
-        - get_master_view
+tasks:
+  main:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() and (ctx().session == '') }}"
+        do:
+          - login
+      - when: "{{ succeeded() and (ctx().session != '') }}"
+        do:
+          - get_master_server
 
-    get_master_view:
-      action: menandmice.get_dns_views
-      input:
-        session: "{{ _.session }}"
-        server: "{{ _.server }}"
-        dns_server_ref: "{{ _.master_server_ref }}"
-      publish:
-        master_view_ref: "{{ task('get_master_view').result.result.dnsViews.dnsView[0].ref }}"
-      on-success:
-        - build_master_zone
+  login:
+    action: menandmice.login
+    input:
+      connection: "{{ ctx().connection }}"
+      server: "{{ ctx().server }}"
+      username: "{{ ctx().username }}"
+      password: "{{ ctx().password }}"
+      port: "{{ ctx().port }}"
+      transport: "{{ ctx().transport }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - session: "{{ result().result.session }}"
+        do:
+          - get_master_server
 
-    build_master_zone:
-      action: std.noop
-      publish:
-        master_zone:
-          name: "{{ _.zone_name }}"
-          dnsViewRef: "{{ _.master_view_ref }}"
-          authority: "{{ _.master_server }}"
-          type: "Master"
-      on-success:
-        - add_master_zone
+  get_master_server:
+    action: menandmice.get_dns_servers
+    input:
+      session: "{{ ctx().session }}"
+      server: "{{ ctx().server }}"
+      filter: "name: {{ ctx().master_server }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - master_server_obj: "{{ result().result.dnsServers.dnsServer[0] }}"
+        do:
+          - parse_master_server
 
-    add_master_zone:
-      action: menandmice.add_dns_zone
-      input:
-        session: "{{ _.session }}"
-        server: "{{ _.server }}"
-        dns_zone: "{{ _.master_zone }}"
-      publish:
-        master_zone_ref: "{{ task('add_master_zone').result.result }}"
+  parse_master_server:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - master_server_ref: "{{ ctx().master_server_obj.ref }}"
+          - master_server_ip: "{{ ctx().master_server_obj.address }}"
+        do:
+          - get_master_view
+
+  get_master_view:
+    action: menandmice.get_dns_views
+    input:
+      session: "{{ ctx().session }}"
+      server: "{{ ctx().server }}"
+      dns_server_ref: "{{ ctx().master_server_ref }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - master_view_ref: "{{ result().result.dnsViews.dnsView[0].ref }}"
+        do:
+          - build_master_zone
+
+  build_master_zone:
+    action: core.noop
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - master_zone:
+              name: "{{ ctx().zone_name }}"
+              dnsViewRef: "{{ ctx().master_view_ref }}"
+              authority: "{{ ctx().master_server }}"
+              type: Master
+        do:
+          - add_master_zone
+
+  add_master_zone:
+    action: menandmice.add_dns_zone
+    input:
+      session: "{{ ctx().session }}"
+      server: "{{ ctx().server }}"
+      dns_zone: "{{ ctx().master_zone }}"
+    next:
+      - when: "{{ succeeded() }}"
+        publish:
+          - master_zone_ref: "{{ result().result }}"
+
+output:
+  - master_server_ref: "{{ ctx().master_server_ref }}"
+  - master_server_ip: "{{ ctx().master_server_ip }}"
+  - master_view_ref: "{{ ctx().master_view_ref }}"
+  - master_zone_ref: "{{ ctx().master_zone_ref }}"

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - mice
     - ipam
     - dns
-version: 0.1.3
+version: 0.1.4
 author: Encore Technologies
 email: code@encore.tech

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - mice
     - ipam
     - dns
-version: 0.1.4
+version: 1.0.0
 author: Encore Technologies
 email: code@encore.tech

--- a/tests/test_action_lib_get_zone_dns_records.py
+++ b/tests/test_action_lib_get_zone_dns_records.py
@@ -1,4 +1,4 @@
-from encore_base_action_test_case import EncoreBaseActionTestCase
+from men_and_mice_base_action_test_case import MenAndMiceBaseActionTestCase
 
 from get_zone_dns_records import GetZoneDNSRecords
 from st2common.runners.base_action import Action
@@ -7,7 +7,7 @@ import mock
 import requests
 
 
-class GetZoneDNSRecordsTestCase(EncoreBaseActionTestCase):
+class GetZoneDNSRecordsTestCase(MenAndMiceBaseActionTestCase):
     __test__ = True
     action_cls = GetZoneDNSRecords
 
@@ -33,6 +33,20 @@ class GetZoneDNSRecordsTestCase(EncoreBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, GetZoneDNSRecords)
         self.assertIsInstance(action, Action)
+
+    def test_check_dns_name_missing(self):
+        action = self.get_action_instance({})
+        test_name = "test.home.local"
+        expected_value = "test.home.local."
+        result_value = action.check_dns_name(test_name)
+        self.assertEqual(result_value, expected_value)
+
+    def test_check_dns_name_not_missing(self):
+        action = self.get_action_instance({})
+        test_name = "test.home.local."
+        expected_value = "test.home.local."
+        result_value = action.check_dns_name(test_name)
+        self.assertEqual(result_value, expected_value)
 
     @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
     def test_get_dns_zone_success(self, mock_client):

--- a/tests/test_action_lib_get_zone_dns_records.py
+++ b/tests/test_action_lib_get_zone_dns_records.py
@@ -1,0 +1,309 @@
+from encore_base_action_test_case import EncoreBaseActionTestCase
+
+from get_zone_dns_records import GetZoneDNSRecords
+from st2common.runners.base_action import Action
+
+import mock
+import requests
+
+
+class GetZoneDNSRecordsTestCase(EncoreBaseActionTestCase):
+    __test__ = True
+    action_cls = GetZoneDNSRecords
+
+    def _mock_response(self, status=200, content="CONTENT", json_data=None, raise_for_status=None):
+        """Since we will be makeing alot of rest calls that
+        all raise for status, we are creating this helper
+        method to build the mock reponse for us to reduce
+        duplicated code.
+        """
+        mock_resp = mock.Mock()
+        mock_resp.raise_for_status = mock.Mock()
+        if raise_for_status:
+            mock_resp.raise_for_status.side_effect = raise_for_status
+        mock_resp.status_code = status
+        mock_resp.content = content
+        if json_data:
+            mock_resp.json = mock.Mock(
+                return_value=json_data
+            )
+        return mock_resp
+
+    def test_init(self):
+        action = self.get_action_instance({})
+        self.assertIsInstance(action, GetZoneDNSRecords)
+        self.assertIsInstance(action, Action)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_zone_success(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_domain": "test.name"}
+        expected_ref = "test_ref"
+        expected_json = {'result': {'dnsZones': [{'ref': expected_ref}]}}
+        mock_response = self._mock_response(json_data=expected_json)
+        mock_client.get.return_value = mock_response
+        result = action.get_dns_zone(test_dict['url'], mock_client, test_dict['dns_domain'])
+        mock_client.get.assert_called_with("abc/DNSZones?filter=type:^Master$ name:^test.name.$")
+        self.assertEqual(result, expected_ref)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_zone_error(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_domain": "test.name"}
+        mock_response = self._mock_response(status=404,
+                            raise_for_status=requests.exceptions.HTTPError("Unknown Site"))
+        mock_client.get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            action.get_dns_zone(test_dict['url'], mock_client, test_dict['dns_domain'])
+
+        mock_client.get.assert_called_with("abc/DNSZones?filter=type:^Master$ name:^test.name.$")
+        self.assertTrue('Unknown Site' in context.exception)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_records_success(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_zone_ref": "test/123"}
+        expected_ref = [{'ref': 'test'}]
+        expected_json = {'result': {'dnsRecords': expected_ref}}
+        mock_response = self._mock_response(json_data=expected_json)
+        mock_client.get.return_value = mock_response
+        result = action.get_dns_records(test_dict['url'], mock_client, test_dict['dns_zone_ref'])
+        mock_client.get.assert_called_with("abc/test/123/DNSRecords?filter=type:^A$")
+        self.assertEqual(result, expected_ref)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_records_error(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_zone_ref": "test/123"}
+        mock_response = self._mock_response(status=404,
+                            raise_for_status=requests.exceptions.HTTPError("Unknown Site"))
+        mock_client.get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            action.get_dns_records(test_dict['url'], mock_client, test_dict['dns_zone_ref'])
+
+        mock_client.get.assert_called_with("abc/test/123/DNSRecords?filter=type:^A$")
+        self.assertTrue('Unknown Site' in context.exception)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_resolve_fqdn_success(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_record": {'ref': 'test/123',
+                                    'name': 'test_name',
+                                    'dnsZoneRef': 'test/5'}}
+        expected_result = "test_name.domain.tld"
+        expected_json = {'result': {'dnsZone': {'name': 'domain.tld'}}}
+        mock_response = self._mock_response(json_data=expected_json)
+        mock_client.get.return_value = mock_response
+        result = action.resolve_fqdn(test_dict['url'], mock_client, test_dict['dns_record'])
+        mock_client.get.assert_called_with("abc/test/5")
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_resolve_fqdn_success_extra(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_record": {'ref': 'test/123',
+                                    'name': 'test_name',
+                                    'dnsZoneRef': 'test/5'}}
+        expected_result = "test_name.domain.tld"
+        expected_json = {'result': {'dnsZone': {'name': 'domain.tld.'}}}
+        mock_response = self._mock_response(json_data=expected_json)
+        mock_client.get.return_value = mock_response
+        result = action.resolve_fqdn(test_dict['url'], mock_client, test_dict['dns_record'])
+        mock_client.get.assert_called_with("abc/test/5")
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_resolve_fqdn_error(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_record": {'ref': 'test/123',
+                                    'name': 'test_name',
+                                    'dnsZoneRef': 'test/5'}}
+        mock_response = self._mock_response(status=404,
+                            raise_for_status=requests.exceptions.HTTPError("Unknown Site"))
+        mock_client.get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            action.resolve_fqdn(test_dict['url'], mock_client, test_dict['dns_record'])
+
+        mock_client.get.assert_called_with("abc/test/5")
+        self.assertTrue('Unknown Site' in context.exception)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.resolve_fqdn')
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_related_records_success(self, mock_client, mock_fqdn):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_record_ref": "test/123"}
+        expected_records = [{'ref': 'test'}]
+        expected_result = [{'ref': 'test',
+                            'name_fqdn': 'test.domain.tld'}]
+        expected_json = {'result': {'dnsRecords': expected_records}}
+        mock_response = self._mock_response(json_data=expected_json)
+        mock_client.get.return_value = mock_response
+        mock_fqdn.return_value = 'test.domain.tld'
+        result = action.get_dns_related_records(test_dict['url'],
+                                                mock_client,
+                                                test_dict['dns_record_ref'])
+        mock_client.get.assert_called_with("abc/test/123/RelatedDNSRecords")
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_related_records_none(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_record_ref": "test/123"}
+        expected_records = []
+        expected_json = {'result': {'dnsRecords': expected_records}}
+        mock_response = self._mock_response(json_data=expected_json)
+        mock_client.get.return_value = mock_response
+        result = action.get_dns_related_records(test_dict['url'],
+                                                mock_client,
+                                                test_dict['dns_record_ref'])
+        mock_client.get.assert_called_with("abc/test/123/RelatedDNSRecords")
+        self.assertEqual(result, expected_records)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_dns_related_records_error(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_record_ref": "test/123"}
+        mock_response = self._mock_response(status=404,
+                            raise_for_status=requests.exceptions.HTTPError("Unknown Site"))
+        mock_client.get.return_value = mock_response
+
+        with self.assertRaises(requests.exceptions.HTTPError) as context:
+            action.get_dns_related_records(test_dict['url'],
+                                           mock_client,
+                                           test_dict['dns_record_ref'])
+
+        mock_client.get.assert_called_with("abc/test/123/RelatedDNSRecords")
+        self.assertTrue('Unknown Site' in context.exception)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.get_dns_related_records')
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_build_dns_information(self, mock_client, mock_get_dns_related_records):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_records": [{'ref': 'test/123',
+                                    'name': 'test_name',
+                                    'dnsZoneRef': 'test/5'}],
+                     "dns_domain": "domain.tld"}
+        expected_related_records = [{'name': 'test_name_2'}]
+        expected_result = {
+            'test_name.domain.tld': {
+                'ref': 'test/123',
+                'name': 'test_name',
+                'dnsZoneRef': 'test/5',
+                'related_records': expected_related_records
+            }
+        }
+        mock_get_dns_related_records.return_value = expected_related_records
+        result = action.build_dns_information(test_dict['url'],
+                                              mock_client,
+                                              test_dict['dns_records'],
+                                              test_dict['dns_domain'])
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.get_dns_related_records')
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_build_dns_information_no_related(self, mock_client, mock_get_dns_related_records):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_records": [{'ref': 'test/123',
+                                    'name': 'test_name',
+                                    'dnsZoneRef': 'test/5'}],
+                     "dns_domain": "domain.tld"}
+        expected_related_records = []
+        expected_result = {
+            'test_name.domain.tld': {
+                'ref': 'test/123',
+                'name': 'test_name',
+                'dnsZoneRef': 'test/5',
+                'related_records': expected_related_records
+            }
+        }
+        mock_get_dns_related_records.return_value = expected_related_records
+        result = action.build_dns_information(test_dict['url'],
+                                              mock_client,
+                                              test_dict['dns_records'],
+                                              test_dict['dns_domain'])
+        self.assertEqual(result, expected_result)
+
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_get_build_dns_information_none(self, mock_client):
+        action = self.get_action_instance(self.config_good)
+        connection_name = 'base'
+        connection_config = self.config_good['menandmice'][connection_name]
+        test_dict = {"url": connection_config['server'],
+                     "dns_records": [],
+                     "dns_domain": "domain.tld"}
+        expected_result = {}
+        result = action.build_dns_information(test_dict['url'],
+                                              mock_client,
+                                              test_dict['dns_records'],
+                                              test_dict['dns_domain'])
+        self.assertEqual(result, expected_result)
+
+    @mock.patch("get_zone_dns_records.GetZoneDNSRecords.build_dns_information")
+    @mock.patch("get_zone_dns_records.GetZoneDNSRecords.get_dns_records")
+    @mock.patch("get_zone_dns_records.GetZoneDNSRecords.get_dns_zone")
+    @mock.patch('get_zone_dns_records.GetZoneDNSRecords.mm_build_client')
+    def test_run(self,
+                 mock_build_client,
+                 mock_get_dns_zone,
+                 mock_get_dns_records,
+                 mock_build_dns_information):
+        action = self.get_action_instance({})
+        test_dict = {"dns_domain": "test.local"}
+        client = "client"
+        url = "url"
+        dns_zone_ref = "test/4"
+        dns_records = [{'name': 'test_name',
+                        'ref': 'test/123'}]
+        expected_result = {
+            'test_name.test.local': {
+                'name': 'test_name',
+                'ref': 'test/123'
+            }
+        }
+
+        mock_build_client.return_value = (url, client)
+        mock_get_dns_zone.return_value = dns_zone_ref
+        mock_get_dns_records.return_value = dns_records
+        mock_build_dns_information.return_value = expected_result
+
+        result = action.run(**test_dict)
+        self.assertEqual(result, expected_result)

--- a/tests/test_action_lib_run_operation.py
+++ b/tests/test_action_lib_run_operation.py
@@ -26,6 +26,13 @@ class TestActionLibRunOperation(MenAndMiceBaseActionTestCase):
         result = action.snake_to_camel(snake)
         self.assertEqual(result, camel)
 
+    def test_snake_to_camel_exclude_dhcp(self):
+        action = self.get_action_instance({})
+        snake = "exclude_dhcp"
+        camel = "excludeDHCP"
+        result = action.snake_to_camel(snake)
+        self.assertEqual(result, camel)
+
     def test_get_del_arg_present(self):
         action = self.get_action_instance({})
         test_dict = {"key1": "value1",


### PR DESCRIPTION
Added utility action/workflow to get all dns records and related records in a given zone.
Added utility action/workflow to claim a dns record in the proper zone. If using an A record it will either claim the next available ip or if one is given it will use that.
Fixed issue with remove dns record where if a ptr record does exist (it hasn't been auto created yet) then method fails.
Converted all workflows to orquesta.